### PR TITLE
Redirect contact booking button to Calendly

### DIFF
--- a/project/src/pages/Contact.tsx
+++ b/project/src/pages/Contact.tsx
@@ -200,7 +200,7 @@ const Contact = () => {
                   de votre projet d'automatisation.
                 </p>
                 <a
-                  href="https://calendly.com/jordan-autoia"
+                  href="https://calendly.com/jordanmmo/decouverte-ia-pro?month=2025-08"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline-flex items-center bg-blue-700 text-white px-6 py-3 rounded-lg hover:bg-blue-800 transition-colors duration-200 font-semibold group"


### PR DESCRIPTION
## Summary
- update contact page booking button to open personal Calendly link in new tab

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68962e0bdd588331b4991a41d74a4139