### PR TITLE
fix: SPA routing fallback for Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/:path*",
+      "destination": "/"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add SPA-friendly rewrite rule for Vercel

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68965c27b4048331bd2439bd41171a09